### PR TITLE
Added cursor execute arg functionality.

### DIFF
--- a/luxon/core/db/base/cursor.py
+++ b/luxon/core/db/base/cursor.py
@@ -183,8 +183,12 @@ class Cursor(BaseExeptions):
 
         Reference PEP-0249
         """
+
         with Timer() as elapsed:
             try:
+                if args is not None and not isinstance(args, (dict, list)):
+                    args = [ args ]
+
                 query, args = args_to(query, args, self._conn.DEST_FORMAT)
                 if args is not None:
                     self._crsr.execute(query, args)


### PR DESCRIPTION
Cursor.execute method can now accept arg that is not list or dict.
It will automatically convert none dict, list instance to single
arguement in list.